### PR TITLE
fix Takagi factorization for degenerate singular values

### DIFF
--- a/ckmutil/diag.py
+++ b/ckmutil/diag.py
@@ -1,6 +1,7 @@
 """Functions for the diagonalization of fermion mass matrices."""
 
 import numpy as np
+from scipy.linalg import fractional_matrix_power
 
 def msvd(m):
   """Modified singular value decomposition.
@@ -24,6 +25,10 @@ def mtakfac(m):
   are sorted in ascending order (small to large).
   """
   u, s, v = msvd(np.asarray(m, dtype=complex))
-  f = np.sqrt(u.conj().T @ v.conj())
-  w = v @ f
+  z2 = u.conj().T @ v.conj()
+  if np.all(np.abs(z2 - np.diag(np.diag(z2))) < 1e-14): # if z2 is diagonal
+    z = np.sqrt(z2)
+  else:
+    z = fractional_matrix_power(z2,1/2)
+  w = v @ z
   return w, s

--- a/ckmutil/test_diag.py
+++ b/ckmutil/test_diag.py
@@ -11,6 +11,13 @@ Mc = np.array([[ 0.82469+0.62495j,  0.37768+0.28744j,  0.40011+0.93478j],
 Mcs = np.array([[ 0.82794+0.4311j ,  0.33124+0.73104j,  0.77668+0.14696j],
        [ 0.33124+0.73104j,  0.18407+0.67383j,  0.46557+0.14199j],
        [ 0.77668+0.14696j,  0.46557+0.14199j,  0.94771+0.73933j]])
+# complex symmetric with two degenerate singular values
+Mcsd = np.array([[ 0.20019824+0.21595061j,  0.0563654 -0.14476247j,
+         0.09818666-0.1975587j ],
+       [ 0.0563654 -0.14476247j,  0.2457214 -0.00074698j,
+        -0.04078761+0.19632891j],
+       [ 0.09818666-0.1975587j , -0.04078761+0.19632891j,
+         0.19381973+0.13898357j]])
 
 class TestDiag(unittest.TestCase):
     def test_svd(self):
@@ -24,3 +31,8 @@ class TestDiag(unittest.TestCase):
         npt.assert_array_equal(Mcs - Mcs.T, np.zeros((3,3)))
         U, S = mtakfac(Mcs)
         npt.assert_array_almost_equal(U.conj() @ np.diag(S) @ U.conj().T, Mcs, decimal=6)
+
+    def test_takfac_degenerate(self):
+        npt.assert_array_equal(Mcsd - Mcsd.T, np.zeros((3,3)))
+        U, S = mtakfac(Mcsd)
+        npt.assert_array_almost_equal(U.conj() @ np.diag(S) @ U.conj().T, Mcsd, decimal=6)


### PR DESCRIPTION
So far, the Takagi factorization only worked correctly for matrices with distinct singular values. This PR provides a fix for Takagi factorizations of matrices with degenerate singular values (cf. https://www.sciencedirect.com/science/article/abs/pii/S0096300314002239).