### PR TITLE
fix extraction of angles and phases of unitary matrices

### DIFF
--- a/ckmutil/phases.py
+++ b/ckmutil/phases.py
@@ -10,33 +10,128 @@ def mixing_phases(U):
     in standard parametrization, starting from a matrix with arbitrary phase
     convention."""
     f = {}
-    # angles
-    f['t13'] = asin(abs(U[0,2]))
-    if U[0,0] == 0:
-        f['t12'] = pi/2
-    else:
-        f['t12'] = atan(abs(U[0,1])/abs(U[0,0]))
-    if U[2,2] == 0:
-        f['t23'] = pi/2
-    else:
-        f['t23'] = atan(abs(U[1,2])/abs(U[2,2]))
-    s12 = sin(f['t12'])
-    c12 = cos(f['t12'])
+    # angle t13
+    f['t13'] = pi/2 if abs(U[0,2]) >= 1 else asin(abs(U[0,2]))
     s13 = sin(f['t13'])
     c13 = cos(f['t13'])
-    s23 = sin(f['t23'])
-    c23 = cos(f['t23'])
-    # standard phase
-    if (s12*s23) == 0 or (c12*c13**2*c23*s13) == 0:
+    if abs(c13) < 1e-7: # special case since U[0,0], U[0,1], U[1,2], U[2,2] are all zero
+        # angles t12 and t23
+        f['t12'] = pi/2 if abs(U[1,1]) == 0 else atan(abs(U[2,1])/abs(U[1,1]))
+        f['t23'] = 0
+        s12 = sin(f['t12'])
+        c12 = cos(f['t12'])
+        # standard phase
         f['delta'] = 0
+        # Majorana phases
+        f['phi2'] = 0
+        f['delta1'] = phase(U[0, 2])
+        if abs(s12) < 1e-7:
+            f['phi1'] = 0
+            f['delta2'] = phase(U[1,1])
+            f['delta3'] = phase(-U[2,0])
+        elif abs(c12) < 1e-7:
+            f['phi1'] = 0
+            f['delta2'] = phase(-U[1,0])
+            f['delta3'] = phase(-U[2,1])
+        else:
+            f['delta2'] = phase(U[1,1])
+            f['delta3'] = phase(-U[2,1])
+            f['phi1'] = 2*phase(-exp(1j*f['delta2'])*U[1,0].conj())
     else:
-        f['delta'] = -phase((U[0,0].conj()*U[0,2]*U[2,0]*U[2,2].conj()/(c12*c13**2*c23*s13) + c12*c23*s13)/(s12*s23))
-    # Majorana phases
-    f['delta1']  = phase(exp(1j*f['delta']) * U[0, 2])
-    f['delta2']  = phase(U[1, 2])
-    f['delta3']  = phase(U[2, 2])
-    f['phi1'] = 2*phase(exp(1j*f['delta1']) * U[0, 0].conj())
-    f['phi2'] = 2*phase(exp(1j*f['delta1']) * U[0, 1].conj())
+        # angles t12 and t23
+        f['t12'] = pi/2 if abs(U[0,0]) == 0 else atan(abs(U[0,1])/abs(U[0,0]))
+        f['t23'] = pi/2 if abs(U[2,2]) == 0 else atan(abs(U[1,2])/abs(U[2,2]))
+        s12 = sin(f['t12'])
+        c12 = cos(f['t12'])
+        s23 = sin(f['t23'])
+        c23 = cos(f['t23'])
+        # standard phase
+        if (
+            abs(s12) < 1e-7
+            or abs(s13) < 1e-7
+            or abs(s23) < 1e-7
+            or abs(c12) < 1e-7
+            or abs(c23) < 1e-7
+        ):
+            f['delta'] = 0
+        else:
+            f['delta'] = -phase((U[0,0].conj()*U[0,2]*U[2,0]*U[2,2].conj()/(c12*c13**2*c23*s13) + c12*c23*s13)/(s12*s23))
+        # Majorana phases
+        if abs(s12) < 1e-7:
+            if abs(s13) < 1e-7:
+                f['phi1'] = 0
+                f['delta1'] = phase(U[0,0])
+            else:
+                f['phi1'] = 2*phase(U[0,0].conj()*U[0,2])
+                f['delta1'] = phase(U[0,2])
+            if abs(s23) < 1e-7:
+                f['phi2'] = 0
+                f['delta2'] = phase(U[1,1])
+                f['delta3'] = phase(U[2,2])
+            elif abs(c23) < 1e-7:
+                f['phi2'] = 0
+                f['delta2'] = phase(U[1,2])
+                f['delta3'] = phase(-U[2,1])
+            else:
+                f['phi2'] = 2*phase(U[1,1].conj()*U[1,2])
+                f['delta2'] = phase(U[1,2])
+                f['delta3'] = phase(U[2,2])
+        elif abs(c12) < 1e-7:
+            if abs(s13) < 1e-7:
+                f['phi2'] = 0
+                f['delta1'] = phase(U[0,1])
+            else:
+                f['phi2'] = 2*phase(U[0,1].conj()*U[0,2])
+                f['delta1'] = phase(U[0,2])
+            if abs(s23) < 1e-7:
+                f['phi1'] = 0
+                f['delta2'] = phase(-U[1,0])
+                f['delta3'] = phase(U[2,2])
+            elif abs(c23) < 1e-7:
+                f['phi1'] = 0
+                f['delta2'] = phase(U[1,2])
+                f['delta3'] = phase(U[2,0])
+            else:
+                f['phi1'] = 2*phase(U[2,0].conj()*U[2,2])
+                f['delta2'] = phase(U[1,2])
+                f['delta3'] = phase(U[2,2])
+        elif abs(s13) < 1e-7:
+            if abs(s23) < 1e-7:
+                f['phi2'] = 0
+                f['phi1'] = 2*phase(U[0,0].conj()*U[0,1])
+                f['delta1'] = phase(U[0,1])
+                f['delta2'] = phase(U[1,1])
+                f['delta3'] = phase(U[2,2])
+            elif abs(c23) < 1e-7:
+                f['phi2'] = 0
+                f['phi1'] = 2*phase(U[0,0].conj()*U[0,1])
+                f['delta1'] = phase(U[0,1])
+                f['delta2'] = phase(U[1,2])
+                f['delta3'] = phase(-U[2,1])
+            else:
+                f['phi1'] = 2*phase(U[2,0].conj()*U[2,2])
+                f['phi2'] = 2*phase(U[1,1].conj()*U[1,2])
+                f['delta1'] = phase(exp(1j*f['phi1']/2)*U[0,0])
+                f['delta2'] = phase(U[1,2])
+                f['delta3'] = phase(U[2,2])
+        elif abs(s23) < 1e-7:
+            f['phi1'] = 2*phase(U[0,0].conj()*U[0,2])
+            f['phi2'] = 2*phase(U[0,1].conj()*U[0,2])
+            f['delta1'] = phase(U[0,2])
+            f['delta2'] = phase(exp(1j*f['phi2']/2)*U[1,1])
+            f['delta3'] = phase(U[2,2])
+        elif abs(c23) < 1e-7:
+            f['phi1'] = 2*phase(U[0,0].conj()*U[0,2])
+            f['phi2'] = 2*phase(U[0,1].conj()*U[0,2])
+            f['delta1'] = phase(U[0,2])
+            f['delta2'] = phase(U[1,2])
+            f['delta3'] = phase(exp(1j*f['phi1']/2)*U[2,0])
+        else:
+            f['delta1'] = phase(exp(1j*f['delta'])*U[0,2])
+            f['delta2'] = phase(U[1,2])
+            f['delta3'] = phase(U[2,2])
+            f['phi1'] = 2*phase(exp(1j*f['delta1'])*U[0,0].conj())
+            f['phi2'] = 2*phase(exp(1j*f['delta1'])*U[0,1].conj())
     return f
 
 def rephase_standard(UuL, UdL, UuR, UdR):

--- a/ckmutil/test_phases.py
+++ b/ckmutil/test_phases.py
@@ -23,10 +23,7 @@ def random_angle():
 def random_phase():
     return np.random.uniform(0,2*pi)
 def random_unitary_matrix(angles):
-    t1, t2, t3 = (
-        random_angle() if angle == 'rand' else angle
-        for angle in angles
-    )
+    t1, t2, t3 = (random_angle() if angle == 'rand' else angle for angle in angles)
     return unitary_matrix(
         t1, t2, t3,
         random_phase(),
@@ -36,7 +33,7 @@ def random_unitary_matrix(angles):
 
 class TestPhases(unittest.TestCase):
     def test_parameter_extraction(self):
-        for angles in product([0,np.pi, 'rand'],repeat=3):
+        for angles in product([0,np.pi/2, 'rand'],repeat=3):
             for _ in range(100): # repeat 100 times to avoid random agreement
                 M = random_unitary_matrix(angles)
                 f = mixing_phases(M)

--- a/ckmutil/test_phases.py
+++ b/ckmutil/test_phases.py
@@ -23,9 +23,10 @@ def random_angle():
 def random_phase():
     return np.random.uniform(0,2*pi)
 def random_unitary_matrix(angles):
-    t1 = random_angle() if angles[0] == 'rand' else angles[0]
-    t2 = random_angle() if angles[1] == 'rand' else angles[1]
-    t3 = random_angle() if angles[2] == 'rand' else angles[2]
+    t1, t2, t3 = (
+        random_angle() if angle == 'rand' else angle
+        for angle in angles
+    )
     return unitary_matrix(
         t1, t2, t3,
         random_phase(),

--- a/ckmutil/test_phases.py
+++ b/ckmutil/test_phases.py
@@ -33,7 +33,7 @@ def random_unitary_matrix(angles):
 
 class TestPhases(unittest.TestCase):
     def test_parameter_extraction(self):
-        for angles in product([0,np.pi/2, 'rand'],repeat=3):
+        for angles in product([0, pi/2, 'rand'],repeat=3):
             for _ in range(100): # repeat 100 times to avoid random agreement
                 M = random_unitary_matrix(angles)
                 f = mixing_phases(M)

--- a/ckmutil/test_phases.py
+++ b/ckmutil/test_phases.py
@@ -6,6 +6,7 @@ from ckmutil.diag import msvd, mtakfac
 import numpy as np
 from math import sin, cos
 from cmath import exp
+from itertools import product
 
 # some auxiliary functions
 def diagonal_phase_matrix(a1, a2, a3):
@@ -17,8 +18,29 @@ def unitary_matrix(t12, t13, t23, delta, delta1, delta2, delta3, phi1, phi2):
     ph2 = diagonal_phase_matrix(-phi1/2, -phi2/2, 0)
     ckm = ckm_standard(t12, t13, t23, delta)
     return np.dot(ph1, np.dot(ckm, ph2))
+def random_angle():
+    return np.random.uniform(0,pi/2)
+def random_phase():
+    return np.random.uniform(0,2*pi)
+def random_unitary_matrix(angles):
+    t1 = random_angle() if angles[0] == 'rand' else angles[0]
+    t2 = random_angle() if angles[1] == 'rand' else angles[1]
+    t3 = random_angle() if angles[2] == 'rand' else angles[2]
+    return unitary_matrix(
+        t1, t2, t3,
+        random_phase(),
+        random_phase(), random_phase(), random_phase(),
+        random_phase(), random_phase()
+    )
 
 class TestPhases(unittest.TestCase):
+    def test_parameter_extraction(self):
+        for angles in product([0,np.pi, 'rand'],repeat=3):
+            for _ in range(100): # repeat 100 times to avoid random agreement
+                M = random_unitary_matrix(angles)
+                f = mixing_phases(M)
+                npt.assert_array_almost_equal(unitary_matrix(**f), M, decimal=7)
+
     def test_rephasing(self):
         # a random unitary matrix
         U = np.array([[-0.4825-0.5529j,  0.6076-0.0129j,  0.1177+0.2798j],


### PR DESCRIPTION
When extracting the angles and phases of a generic unitary matrix, one has to treat the cases separately in which some angles are 0 or $\pi/2$ since in these cases some of the entries of the unitary matrix vanish. Including the case where no angle is 0 or $\pi/2$, there are in total 27 different cases. The current implementation yields correct results for only 4 of these cases. This PR fixes this issue and implements a test checking all cases.

This PR should also fix the issues https://github.com/wilson-eft/wilson/issues/63 and https://github.com/wilson-eft/wilson/issues/74 that seem to have been caused by a wrong extraction of the phases.