### PR TITLE
update CKM parameterizations and add new beta-gamma parametrization

### DIFF
--- a/ckmutil/ckm.py
+++ b/ckmutil/ckm.py
@@ -10,11 +10,15 @@ def ckm_standard(t12, t13, t23, delta):
 
     Parameters
     ----------
-
     - `t12`: CKM angle $\theta_{12}$ in radians
     - `t13`: CKM angle $\theta_{13}$ in radians
     - `t23`: CKM angle $\theta_{23}$ in radians
     - `delta`: CKM phase $\delta=\gamma$ in radians
+
+    Returns
+    -------
+    - `v`: CKM matrix in the standard parametrization and standard phase
+        convention
     """
     c12 = cos(t12)
     c13 = cos(t13)
@@ -32,14 +36,442 @@ def ckm_standard(t12, t13, t23, delta):
         -(c23*exp(1j*delta)*s12*s13) - c12*s23,
         c13*c23]])
 
-def tree_to_wolfenstein(Vus, Vub, Vcb, gamma):
-    laC = Vus/sqrt(1-Vub**2)
-    A = Vcb/sqrt(1-Vub**2)/laC**2
-    rho = Vub*cos(gamma)/A/laC**3
-    eta = Vub*sin(gamma)/A/laC**3
-    rhobar = rho*(1 - laC**2/2.)
-    etabar = eta*(1 - laC**2/2.)
+def gamma_to_delta(t12, t13, t23, gamma, delta_expansion_order=None):
+    r"""CKM phase $\delta$ in terms of $\gamma$.
+
+    By default, no analytical approximation is made for the CKM phase
+    $\delta$ but the optional argument `delta_expansion_order` allows to use
+    the very accurate analytical approximation $\delta=\gamma$ for
+    `delta_expansion_order=0` or to include higher-order corrections to this
+    approximation for `delta_expansion_order=1` or `delta_expansion_order=2`.
+
+    Parameters
+    ----------
+    - `t12`: CKM angle $\theta_{12}$ in radians
+    - `t13`: CKM angle $\theta_{13}$ in radians
+    - `t23`: CKM angle $\theta_{23}$ in radians
+    - `gamma`: Unitarity Triangle angle $\gamma$ in radians
+
+    Optional parameters
+    -------------------
+    - `delta_expansion_order` (optional): `None` (default), `0`, `1`, or `2`.
+        If `None` (default), the exact relation between the CKM phase $\delta$
+        and the Unitarity Triangle angle $\gamma$ is used. If `0`, $\delta$ is
+        set to the value of `gamma`. If `1`, $\delta$ is set to the value of
+        `gamma` plus the leading permille correction $\delta = \gamma +
+        \mathcal{O}(10^{-3})$. If `2`, the next-to-leading order correction is
+        included, $\delta = \gamma + \mathcal{O}(10^{-3}) +
+        \mathcal{O}(10^{-11})$.
+
+    Returns
+    -------
+    - `delta`: CKM phase $\delta$ in radians
+    """
+    if delta_expansion_order == 0:
+        delta = gamma
+    else:
+        s13 = np.sin(t13)
+        tan12 = np.tan(t12)
+        tan23 = np.tan(t23)
+        k = s13 * tan23 / tan12
+        if delta_expansion_order == 1:
+            delta = gamma + k * np.sin(gamma)
+        elif delta_expansion_order == 2:
+            delta = gamma + k * sin(gamma) + 1/6 * k**3 * sin(gamma)**3
+        elif delta_expansion_order is None:
+            delta = np.arctan((1 - k**2)/(1/np.tan(gamma) - k * sqrt(1/sin(gamma)**2 - k**2)))
+        else:
+            raise ValueError('delta_expansion_order must be 0, 1, 2, or None.')
+    return delta.real
+
+def beta_gamma_to_delta(beta, gamma, t23, delta_expansion_order=None):
+    r"""CKM phase $\delta$ in terms of $\beta$ and $\gamma$.
+
+    By default, no analytical approximation is made for the CKM phase
+    $\delta$ but the optional argument `delta_expansion_order` allows to use
+    the very accurate analytical approximation $\delta=\gamma$ for
+    `delta_expansion_order=0` or to include higher-order corrections to this
+    approximation for `delta_expansion_order=1` or `delta_expansion_order=2`.
+
+    Parameters
+    ----------
+    - `gamma`: Unitarity Triangle angle $\gamma$ in radians
+    - `beta`: Unitarity Triangle angle $\beta$ in radians
+    - `t23`: CKM angle $\theta_{23}$ in radians
+
+    Optional parameters
+    -------------------
+    - `delta_expansion_order` (optional): `None` (default), `0`, `1`, or `2`.
+        If `None` (default), the exact relation between the CKM phase $\delta$
+        and the Unitarity Triangle angle $\gamma$ is used. If `0`, $\delta$ is
+        set to the value of `gamma`. If `1`, $\delta$ is set to the value of
+        `gamma` plus the leading permille correction $\delta = \gamma +
+        \mathcal{O}(10^{-3})$. If `2`, the next-to-leading order correction is
+        included, $\delta = \gamma + \mathcal{O}(10^{-3}) +
+        \mathcal{O}(10^{-6})$.
+
+    Returns
+    -------
+    - `delta`: CKM phase $\delta$ in radians
+    """
+    if delta_expansion_order == 0:
+        delta = gamma
+    else:
+        s23 = np.sin(t23)
+        Rb = np.sin(beta) / np.sin(beta + gamma)
+        rhobar = Rb * np.cos(gamma)
+        etabar = Rb * np.sin(gamma)
+        if delta_expansion_order == 1:
+            delta = gamma + s23**2 * etabar
+        elif delta_expansion_order == 2:
+            delta = gamma + s23**2 * etabar + s23**4 * rhobar * etabar
+        elif delta_expansion_order is None:
+            delta = np.arctan(1/(1/np.tan(gamma) - s23**2 * Rb**2 / etabar ))
+        else:
+            raise ValueError('delta_expansion_order must be 0, 1, 2, or None.')
+    return delta.real
+
+def tree_to_standard(Vus, Vub, Vcb, gamma, delta_expansion_order=None):
+    r"""Function to convert from the CKM matrix in the tree parametrization to
+    the CKM matrix in the standard parametrization.
+
+    Parameters
+    ----------
+    - `Vus`: CKM matrix element $V_{us}$
+    - `Vub`: Absolute value of CKM matrix element $|V_{ub}|$
+    - `Vcb`: CKM matrix element $V_{cb}$
+    - `gamma`: Unitarity Triangle angle $\gamma$ in radians
+
+    Optional parameters
+    -------------------
+    - `delta_expansion_order` (optional): `None` (default), `0`, `1`, or `2`.
+        If `None` (default), the exact relation between the CKM phase $\delta$
+        and the Unitarity Triangle angle $\gamma$ is used. If `0`, $\delta$ is
+        set to the value of `gamma`. If `1`, $\delta$ is set to the value of
+        `gamma` plus the leading permille correction $\delta = \gamma +
+        \mathcal{O}(10^{-3})$. If `2`, the next-to-leading order correction is
+        included, $\delta = \gamma + \mathcal{O}(10^{-3}) +
+        \mathcal{O}(10^{-11})$.
+
+    Returns
+    -------
+    - `t12`: CKM angle $\theta_{12}$ in radians
+    - `t13`: CKM angle $\theta_{13}$ in radians
+    - `t23`: CKM angle $\theta_{23}$ in radians
+    - `delta`: CKM phase $\delta$ in radians
+    """
+    s13 = abs(Vub)
+    c13 = sqrt(1 - s13**2)
+    s12 = Vus/c13
+    s23 = Vcb/c13
+    t13 = np.arcsin(s13)
+    t12 = np.arcsin(s12)
+    t23 = np.arcsin(s23)
+    delta = gamma_to_delta(t12, t13, t23, gamma, delta_expansion_order)
+    return t12, t13, t23, delta
+
+def standard_to_tree(t12, t13, t23, delta):
+    r"""Function to convert from the CKM matrix in the standard parametrization
+    to the CKM matrix in the tree parametrization.
+
+    Parameters
+    ----------
+    - `t12`: CKM angle $\theta_{12}$ in radians
+    - `t13`: CKM angle $\theta_{13}$ in radians
+    - `t23`: CKM angle $\theta_{23}$ in radians
+    - `delta`: CKM phase $\delta$ in radians
+
+    Returns
+    -------
+    - `Vus`: CKM matrix element $V_{us}$
+    - `Vub`: Absolute value of CKM matrix element $|V_{ub}|$
+    - `Vcb`: CKM matrix element $V_{cb}$
+    - `gamma`: Unitarity Triangle angle $\gamma$ in radians
+    """
+    s12 = sin(t12)
+    s13 = sin(t13)
+    s23 = sin(t23)
+    c12 = cos(t12)
+    c13 = cos(t13)
+    c23 = cos(t23)
+    Vus = s12 * c13
+    Vub = s13
+    Vcb = s23 * c13
+    gamma = np.angle(-np.exp(1j*delta)/(-s12*c23-c12*s23*s13*np.exp(1j*delta)))
+    return Vus, Vub, Vcb, gamma
+
+def beta_gamma_to_standard(Vus, Vcb, beta, gamma, delta_expansion_order=None):
+    r"""Function to convert from the CKM matrix in the beta-gamma parametrization
+    to the CKM matrix in the standard parametrization.
+
+    Parameters
+    ----------
+    - `Vus`: CKM matrix element $V_{us}$
+    - `Vcb`: CKM matrix element $V_{cb}$
+    - `beta`: Unitarity Triangle angle $\beta$ in radians
+    - `gamma`: Unitarity Triangle angle $\gamma$ in radians
+
+    Optional parameters
+    -------------------
+    - `delta_expansion_order` (optional): `None` (default), `0`, `1`, or `2`.
+        If `None` (default), the exact relation between the CKM phase $\delta$
+        and the Unitarity Triangle angle $\gamma$ is used. If `0`, $\delta$ is
+        set to the value of `gamma`. If `1`, $\delta$ is set to the value of
+        `gamma` plus the leading permille correction $\delta = \gamma +
+        \mathcal{O}(10^{-3})$. If `2`, the next-to-leading order correction is
+        included, $\delta = \gamma + \mathcal{O}(10^{-3}) +
+        \mathcal{O}(10^{-6})$.
+
+    Returns
+    -------
+    - `t12`: CKM angle $\theta_{12}$ in radians
+    - `t13`: CKM angle $\theta_{13}$ in radians
+    - `t23`: CKM angle $\theta_{23}$ in radians
+    - `delta`: CKM phase $\delta$ in radians
+    """
+    Rb = sin(beta) / sin(beta + gamma)
+    rhobar = Rb * cos(gamma)
+    a = Vcb**2 * Vus**2 * (1 - Vcb**2) * Rb**2
+    b = 1 - Vus**2 - Vcb**2 * (2 * rhobar * (1 - Vus**2) - Vcb**2 * Rb**2)
+    c = 2 - Vus**2 - 2 * Vcb**2 * rhobar
+    p = (3*b + c**2)/9
+    q = (27*a + 9*b*c + 2*c**3)/54
+    t = 2*np.sqrt(p)*np.sin(np.arcsin(p**(-3/2)*q)/3)
+    s13 = np.sqrt(t - c/3).real
+    c13 = np.sqrt(1 - s13**2)
+    s12 = Vus/c13
+    s23 = Vcb/c13
+    t13 = np.arcsin(s13)
+    t12 = np.arcsin(s12)
+    t23 = np.arcsin(s23)
+    delta = beta_gamma_to_delta(beta, gamma, t23, delta_expansion_order)
+    return t12, t13, t23, delta
+
+def standard_to_beta_gamma(t12, t13, t23, delta):
+    r"""Function to convert from the CKM matrix in the standard parametrization
+    to the CKM matrix in the beta-gamma parametrization.
+
+    Parameters
+    ----------
+    - `t12`: CKM angle $\theta_{12}$ in radians
+    - `t13`: CKM angle $\theta_{13}$ in radians
+    - `t23`: CKM angle $\theta_{23}$ in radians
+    - `delta`: CKM phase $\delta$ in radians
+
+    Returns
+    -------
+    - `Vus`: CKM matrix element $V_{us}$
+    - `Vcb`: CKM matrix element $V_{cb}$
+    - `beta`: Unitarity Triangle angle $\beta$ in radians
+    - `gamma`: Unitarity Triangle angle $\gamma$ in radians
+    """
+    s12 = sin(t12)
+    s13 = sin(t13)
+    s23 = sin(t23)
+    c12 = cos(t12)
+    c13 = cos(t13)
+    c23 = cos(t23)
+    Vus = s12 * c13
+    Vcb = s23 * c13
+    Vcd_complex = - s12*c23 - c12*s23*s13 * np.exp(1j*delta)
+    Vtd_complex = s12*s23 - c12*c23*s13 * np.exp(1j*delta)
+    beta = np.angle(-Vcd_complex/Vtd_complex)
+    gamma = np.angle(-np.exp(1j*delta)/Vcd_complex)
+    return Vus, Vcb, beta, gamma
+
+def wolfenstein_to_standard(laC, A, rhobar, etabar):
+    r"""Function to convert from the CKM matrix in the Wolfenstein parametrization
+    to the CKM matrix in the standard parametrization.
+
+    Parameters
+    ----------
+    - `laC`: Wolfenstein parameter $\lambda$ (sine of Cabibbo angle)
+    - `A`: Wolfenstein parameter $A$
+    - `rhobar`: Real part of the apex of the Unitarity Triangle
+    - `etabar`: Imaginary part of the apex of the Unitarity Triangle
+
+    Returns
+    -------
+    - `t12`: CKM angle $\theta_{12}$ in radians
+    - `t13`: CKM angle $\theta_{13}$ in radians
+    - `t23`: CKM angle $\theta_{23}$ in radians
+    - `delta`: CKM phase $\delta$ in radians
+
+    Notes
+    -----
+    This function does not rely on an expansion in the Cabibbo angle but
+    defines, to all orders in $\lambda$,
+
+    - $\lambda = \sin\theta_{12}$
+    - $A\lambda^2 = \sin\theta_{23}$
+    - $A\lambda^3(\rho-i \eta) = \sin\theta_{13}e^{-i\delta}$
+
+    where the Wolfenstein parameters $\rho$ and $\eta$ are related to the real
+    and imaginary parts of the apex of the Unitarity Triangle $\bar\rho$ and
+    $\bar\eta$ by
+
+    - $\rho + i \eta = \frac{\sqrt{1-A^2\lambda^4}(\bar\rho + i \bar\eta)}{\sqrt{1-\lambda^2}(1-A^2\lambda^4(\bar\rho + i \bar\eta))}$
+
+    which can be approximated by (but this approximation is not used in this
+    function)
+
+    - $\rho \approx \bar\rho/(1-\lambda^2/2)$
+    - $\eta \approx \bar\eta/(1-\lambda^2/2)$
+    """
+    rho_plus_i_eta = sqrt(1-A**2*laC**4)*(rhobar + 1j*etabar)/(sqrt(1-laC**2)*(1 - A**2*laC**4*(rhobar + 1j*etabar))) # e.g. Eq. (93) in arXiv:2206.07501
+    rho = rho_plus_i_eta.real
+    eta = rho_plus_i_eta.imag
+    s12 = laC
+    s23 = A*laC**2
+    s13 = A*laC**3*np.abs((rho - 1j*eta))
+    delta = np.angle((rho + 1j*eta))
+    t12 = np.arcsin(s12)
+    t13 = np.arcsin(s13)
+    t23 = np.arcsin(s23)
+    return t12, t13, t23, delta
+
+def standard_to_wolfenstein(t12, t13, t23, delta):
+    r"""Function to convert from the CKM matrix in the standard parametrization
+    to the CKM matrix in the Wolfenstein parametrization.
+
+    Parameters
+    ----------
+    - `t12`: CKM angle $\theta_{12}$ in radians
+    - `t13`: CKM angle $\theta_{13}$ in radians
+    - `t23`: CKM angle $\theta_{23}$ in radians
+    - `delta`: CKM phase $\delta$ in radians
+
+    Returns
+    -------
+    - `laC`: Wolfenstein parameter $\lambda$ (sine of Cabibbo angle)
+    - `A`: Wolfenstein parameter $A$
+    - `rhobar`: Real part of the apex of the Unitarity Triangle
+    - `etabar`: Imaginary part of the apex of the Unitarity Triangle
+
+    Notes
+    -----
+    This function does not rely on an expansion in the Cabibbo angle but
+    defines, to all orders in $\lambda$,
+
+    - $\lambda = \sin\theta_{12}$
+    - $A\lambda^2 = \sin\theta_{23}$
+    - $A\lambda^3(\rho-i \eta) = \sin\theta_{13}e^{-i\delta}$
+
+    where the Wolfenstein parameters $\rho$ and $\eta$ are related to the real
+    and imaginary parts of the apex of the Unitarity Triangle $\bar\rho$ and
+    $\bar\eta$ by
+
+    - $\rho + i \eta = \frac{\sqrt{1-A^2\lambda^4}(\bar\rho + i \bar\eta)}{\sqrt{1-\lambda^2}(1-A^2\lambda^4(\bar\rho + i \bar\eta))}$
+
+    which can be approximated by (but this approximation is not used in this
+    function)
+
+    - $\rho \approx \bar\rho/(1-\lambda^2/2)$
+    - $\eta \approx \bar\eta/(1-\lambda^2/2)$
+    """
+    laC = np.sin(t12)
+    A = np.sin(t23)/laC**2
+    rho_minus_i_eta = np.sin(t13) * np.exp(-1j*delta) / (A*laC**3)
+    rho = rho_minus_i_eta.real
+    eta = -rho_minus_i_eta.imag
+    rhobar_plus_i_etabar = sqrt(1-laC**2)*(rho + 1j*eta)/(sqrt(1-A**2*laC**4)+sqrt(1-laC**2)*A**2*laC**4*(rho + 1j*eta)) # e.g. Eq. (92) in arXiv:2206.07501
+    rhobar = rhobar_plus_i_etabar.real
+    etabar = rhobar_plus_i_etabar.imag
     return laC, A, rhobar, etabar
+
+def tree_to_wolfenstein(Vus, Vub, Vcb, gamma, delta_expansion_order=None):
+    r"""Function to convert from the CKM matrix in the tree parametrization to
+    the CKM matrix in the Wolfenstein parametrization.
+
+    Parameters
+    ----------
+    - `Vus`: CKM matrix element $V_{us}$
+    - `Vub`: Absolute value of CKM matrix element $|V_{ub}|$
+    - `Vcb`: CKM matrix element $V_{cb}$
+    - `gamma`: Unitarity Triangle angle $\gamma$ in radians
+
+    Optional parameters
+    -------------------
+    - `delta_expansion_order` (optional): `None` (default), `0`, `1`, or `2`.
+        If `None` (default), the exact relation between the CKM phase $\delta$
+        and the Unitarity Triangle angle $\gamma$ is used. If `0`, $\delta$ is
+        set to the value of `gamma`. If `1`, $\delta$ is set to the value of
+        `gamma` plus the leading permille correction $\delta = \gamma +
+        \mathcal{O}(10^{-3})$. If `2`, the next-to-leading order correction is
+        included, $\delta = \gamma + \mathcal{O}(10^{-3}) +
+        \mathcal{O}(10^{-11})$.
+
+    Returns
+    -------
+    - `laC`: Wolfenstein parameter $\lambda$ (sine of Cabibbo angle)
+    - `A`: Wolfenstein parameter $A$
+    - `rhobar`: Real part of the apex of the Unitarity Triangle
+    - `etabar`: Imaginary part of the apex of the Unitarity Triangle
+
+    Notes
+    -----
+    This function does not rely on an expansion in the Cabibbo angle but
+    defines, to all orders in $\lambda$,
+
+    - $\lambda = \sin\theta_{12}$
+    - $A\lambda^2 = \sin\theta_{23}$
+    - $A\lambda^3(\rho-i \eta) = \sin\theta_{13}e^{-i\delta}$
+
+    where the Wolfenstein parameters $\rho$ and $\eta$ are related to the real
+    and imaginary parts of the apex of the Unitarity Triangle $\bar\rho$ and
+    $\bar\eta$ by
+
+    - $\rho + i \eta = \frac{\sqrt{1-A^2\lambda^4}(\bar\rho + i \bar\eta)}{\sqrt{1-\lambda^2}(1-A^2\lambda^4(\bar\rho + i \bar\eta))}$
+
+    which can be approximated by (but this approximation is not used in this
+    function)
+
+    - $\rho \approx \bar\rho/(1-\lambda^2/2)$
+    - $\eta \approx \bar\eta/(1-\lambda^2/2)$
+    """
+    t12, t13, t23, delta = tree_to_standard(Vus, Vub, Vcb, gamma, delta_expansion_order)
+    return standard_to_wolfenstein(t12, t13, t23, delta)
+
+def wolfenstein_to_tree(laC, A, rhobar, etabar):
+    r"""Function to convert from the CKM matrix in the Wolfenstein parametrization
+    to the CKM matrix in the tree parametrization.
+
+    Parameters
+    ----------
+    - `laC`: Wolfenstein parameter $\lambda$ (sine of Cabibbo angle)
+    - `A`: Wolfenstein parameter $A$
+    - `rhobar`: Real part of the apex of the Unitarity Triangle
+    - `etabar`: Imaginary part of the apex of the Unitarity Triangle
+
+    Returns
+    -------
+    - `Vus`: CKM matrix element $V_{us}$
+    - `Vub`: Absolute value of CKM matrix element $|V_{ub}|$
+    - `Vcb`: CKM matrix element $V_{cb}$
+    - `gamma`: Unitarity Triangle angle $\gamma$ in radians
+
+    Notes
+    -----
+    This function does not rely on an expansion in the Cabibbo angle but
+    defines, to all orders in $\lambda$,
+
+    - $\lambda = \sin\theta_{12}$
+    - $A\lambda^2 = \sin\theta_{23}$
+    - $A\lambda^3(\rho-i \eta) = \sin\theta_{13}e^{-i\delta}$
+
+    where the Wolfenstein parameters $\rho$ and $\eta$ are related to the real
+    and imaginary parts of the apex of the Unitarity Triangle by
+
+    - $\rho + i \eta = \frac{\sqrt{1-A^2\lambda^4}(\bar\rho + i \bar\eta)}{\sqrt{1-\lambda^2}(1-A^2\lambda^4(\bar\rho + i \bar\eta))}$
+
+    which can be approximated by (but this approximation is not used in this
+    function)
+
+    - $\rho \approx \bar\rho/(1-\lambda^2/2)$
+    - $\eta \approx \bar\eta/(1-\lambda^2/2)$
+    """
+    t12, t13, t23, delta = wolfenstein_to_standard(laC, A, rhobar, etabar)
+    return standard_to_tree(t12, t13, t23, delta)
 
 def ckm_wolfenstein(laC, A, rhobar, etabar):
     r"""CKM matrix in the Wolfenstein parametrization and standard phase
@@ -52,59 +484,113 @@ def ckm_wolfenstein(laC, A, rhobar, etabar):
     - $A\lambda^2 = \sin\theta_{23}$
     - $A\lambda^3(\rho-i \eta) = \sin\theta_{13}e^{-i\delta}$
 
-    where $\rho = \bar\rho/(1-\lambda^2/2)$ and
-    $\eta = \bar\eta/(1-\lambda^2/2)$.
+    where the Wolfenstein parameters $\rho$ and $\eta$ are related to the real
+    and imaginary parts of the apex of the Unitarity Triangle $\bar\rho$ and
+    $\bar\eta$ by
+
+    - $\rho + i \eta = \frac{\sqrt{1-A^2\lambda^4}(\bar\rho + i \bar\eta)}{\sqrt{1-\lambda^2}(1-A^2\lambda^4(\bar\rho + i \bar\eta))}$
+
+    which can be approximated by (but this approximation is not used in this
+    function)
+
+    - $\rho \approx \bar\rho/(1-\lambda^2/2)$
+    - $\eta \approx \bar\eta/(1-\lambda^2/2)$
 
     Parameters
     ----------
 
     - `laC`: Wolfenstein parameter $\lambda$ (sine of Cabibbo angle)
     - `A`: Wolfenstein parameter $A$
-    - `rhobar`: Wolfenstein parameter $\bar\rho = \rho(1-\lambda^2/2)$
-    - `etabar`: Wolfenstein parameter $\bar\eta = \eta(1-\lambda^2/2)$
-    """
-    rho = rhobar/(1 - laC**2/2.)
-    eta = etabar/(1 - laC**2/2.)
-    return np.array([[sqrt(1 - laC**2)*sqrt(1 - A**2*laC**6*((-1j)*eta + rho)*((1j)*eta + rho)),
-        laC*sqrt(1 - A**2*laC**6*((-1j)*eta + rho)*((1j)*eta + rho)),
-        A*laC**3*((-1j)*eta + rho)],
-        [-(laC*sqrt(1 - A**2*laC**4)) - A**2*laC**5*sqrt(1 - laC**2)*((1j)*eta + rho),
-        sqrt(1 - laC**2)*sqrt(1 -  A**2*laC**4) - A**2*laC**6*((1j)*eta + rho),
-        A*laC**2*sqrt(1 - A**2*laC**6*((-1j)*eta + rho)*((1j)*eta + rho))],
-        [A*laC**3 - A*laC**3*sqrt(1 - laC**2)*sqrt(1 - A**2*laC**4)*((1j)*eta + rho),
-        -(A*laC**2*sqrt(1 - laC**2)) - A*laC**4*sqrt(1 - A**2*laC**4)*((1j)*eta + rho),
-        sqrt(1 - A**2*laC**4)*sqrt(1 - A**2*laC**6*((-1j)*eta + rho)*((1j)*eta + rho))]])
+    - `rhobar`: Real part of the apex of the Unitarity Triangle
+    - `etabar`: Imaginary part of the apex of the Unitarity Triangle
 
-def ckm_tree(Vus, Vub, Vcb, gamma):
+    Returns
+    -------
+    - `v`: CKM matrix in the Wolfenstein parametrization and standard phase
+        convention
+    """
+    t12, t13, t23, delta = wolfenstein_to_standard(laC, A, rhobar, etabar)
+    return ckm_standard(t12, t13, t23, delta)
+
+def ckm_tree(Vus, Vub, Vcb, gamma, delta_expansion_order=None):
     r"""CKM matrix in the tree parametrization and standard phase
     convention.
 
     In this parametrization, the parameters are directly measured from
     tree-level $B$ decays. It is thus particularly suited for new physics
     analyses because the tree-level decays should be dominated by the Standard
-    Model. This function involves no analytical approximations.
+    Model. By default, no analytical approximation is made for the CKM phase
+    $\delta$ but the optional argument `delta_expansion_order` allows to use
+    the very accurate analytical approximation $\delta=\gamma$ for
+    `delta_expansion_order=0` or to include higher-order corrections to this
+    approximation for `delta_expansion_order=1` or `delta_expansion_order=2`.
 
     Relation to the standard parametrization:
 
     - $V_{us} = \cos \theta_{13} \sin \theta_{12}$
-    - $|V_{ub}| = |\sin \theta_{13}|$
+    - $|V_{ub}| = \sin \theta_{13}$
     - $V_{cb} = \cos \theta_{13} \sin \theta_{23}$
-    - $\gamma=\delta$
+    - $\delta = \gamma + \mathcal{O}(10^{-3})$
 
     Parameters
     ----------
-
     - `Vus`: CKM matrix element $V_{us}$
     - `Vub`: Absolute value of CKM matrix element $|V_{ub}|$
     - `Vcb`: CKM matrix element $V_{cb}$
     - `gamma`: CKM phase $\gamma=\delta$ in radians
+
+    Optional parameters
+    -------------------
+    - `delta_expansion_order` (optional): `None` (default), `0`, `1`, or `2`.
+        If `None` (default), the exact relation between the CKM phase $\delta$
+        and the Unitarity Triangle angle $\gamma$ is used. If `0`, $\delta$ is
+        set to the value of `gamma`. If `1`, $\delta$ is set to the value of
+        `gamma` plus the leading permille correction $\delta = \gamma +
+        \mathcal{O}(10^{-3})$. If `2`, the next-to-leading order correction is
+        included, $\delta = \gamma + \mathcal{O}(10^{-3}) +
+        \mathcal{O}(10^{-11})$.
+
+    Returns
+    -------
+    - `v`: CKM matrix in the tree parametrization and standard phase
     """
-    return np.array([[sqrt(1 - Vub**2)*sqrt(1 - Vus**2/(1 - Vub**2)),
-        Vus,
-        Vub/exp(1j*gamma)],
-        [-((sqrt(1 - Vcb**2/(1 - Vub**2))*Vus)/sqrt(1 - Vub**2)) - (Vub*exp(1j*gamma)*Vcb*sqrt(1 - Vus**2/(1 - Vub**2)))/sqrt(1 - Vub**2),
-        -((Vub*exp(1j*gamma)*Vcb*Vus)/(1 - Vub**2)) + sqrt(1 - Vcb**2/(1 - Vub**2))*sqrt(1 - Vus**2/(1 - Vub**2)),
-        Vcb],
-        [(Vcb*Vus)/(1 - Vub**2) - Vub*exp(1j*gamma)*sqrt(1 - Vcb**2/(1 - Vub**2))*sqrt(1 - Vus**2/(1 - Vub**2)),
-        -((Vub*exp(1j*gamma)*sqrt(1 - Vcb**2/(1 - Vub**2))*Vus)/sqrt(1 - Vub**2)) - (Vcb*sqrt(1 - Vus**2/(1 - Vub**2)))/sqrt(1 - Vub**2),
-        sqrt(1 - Vub**2)*sqrt(1 - Vcb**2/(1 - Vub**2))]])
+    t12, t13, t23, delta = tree_to_standard(Vus, Vub, Vcb, gamma, delta_expansion_order)
+    return ckm_standard(t12, t13, t23, delta)
+
+def ckm_beta_gamma(Vus, Vcb, beta, gamma, delta_expansion_order=None):
+    r"""CKM matrix in the beta-gamma parametrization and standard phase
+    convention.
+
+    In this parametrization, the two angles $\beta$ and $\gamma$ of the
+    Unitarity Triangle are used as input parameters in addition to the CKM
+    matrix elements $V_{us}$ and $V_{cb}$. By default, no analytical
+    approximation is made for the CKM phase $\delta$ but the optional argument
+    `delta_expansion_order` allows to use the very accurate analytical
+    approximation $\delta=\gamma$ for `delta_expansion_order=0` or to include
+    higher-order corrections to this approximation for
+    `delta_expansion_order=1` or `delta_expansion_order=2`.
+
+    Parameters
+    ----------
+    - `Vus`: CKM matrix element $V_{us}$
+    - `Vcb`: CKM matrix element $V_{cb}$
+    - `beta`: Unitarity Triangle angle $\beta$ in radians
+    - `gamma`: Unitarity Triangle angle $\gamma$ in radians
+
+    Optional parameters
+    -------------------
+    - `delta_expansion_order` (optional): `None` (default), `0`, `1`, or `2`.
+        If `None` (default), the exact relation between the CKM phase $\delta$
+        and the Unitarity Triangle angle $\gamma$ is used. If `0`, $\delta$ is
+        set to the value of `gamma`. If `1`, $\delta$ is set to the value of
+        `gamma` plus the leading permille correction $\delta = \gamma +
+        \mathcal{O}(10^{-3})$. If `2`, the next-to-leading order correction is
+        included, $\delta = \gamma + \mathcal{O}(10^{-3}) +
+        \mathcal{O}(10^{-6})$.
+
+    Returns
+    -------
+    - `v`: CKM matrix in the beta-gamma parametrization and standard phase
+    """
+    t12, t13, t23, delta = beta_gamma_to_standard(Vus, Vcb, beta, gamma, delta_expansion_order)
+    return ckm_standard(t12, t13, t23, delta)

--- a/ckmutil/ckm.py
+++ b/ckmutil/ckm.py
@@ -197,7 +197,8 @@ def standard_to_tree(t12, t13, t23, delta):
     Vus = s12 * c13
     Vub = s13
     Vcb = s23 * c13
-    gamma = np.angle(-np.exp(1j*delta)/(-s12*c23-c12*s23*s13*np.exp(1j*delta)))
+    Vcd_complex = - s12*c23 - c12*s23*s13 * np.exp(1j*delta)
+    gamma = np.angle(-np.exp(1j*delta)/Vcd_complex)
     return Vus, Vub, Vcb, gamma
 
 def beta_gamma_to_standard(Vus, Vcb, beta, gamma, delta_expansion_order=None):
@@ -319,12 +320,10 @@ def wolfenstein_to_standard(laC, A, rhobar, etabar):
     - $\eta \approx \bar\eta/(1-\lambda^2/2)$
     """
     rho_plus_i_eta = sqrt(1-A**2*laC**4)*(rhobar + 1j*etabar)/(sqrt(1-laC**2)*(1 - A**2*laC**4*(rhobar + 1j*etabar))) # e.g. Eq. (93) in arXiv:2206.07501
-    rho = rho_plus_i_eta.real
-    eta = rho_plus_i_eta.imag
     s12 = laC
     s23 = A*laC**2
-    s13 = A*laC**3*np.abs((rho - 1j*eta))
-    delta = np.angle((rho + 1j*eta))
+    s13 = A*laC**3*np.abs(rho_plus_i_eta)
+    delta = np.angle(rho_plus_i_eta)
     t12 = np.arcsin(s12)
     t13 = np.arcsin(s13)
     t23 = np.arcsin(s23)
@@ -371,10 +370,8 @@ def standard_to_wolfenstein(t12, t13, t23, delta):
     """
     laC = np.sin(t12)
     A = np.sin(t23)/laC**2
-    rho_minus_i_eta = np.sin(t13) * np.exp(-1j*delta) / (A*laC**3)
-    rho = rho_minus_i_eta.real
-    eta = -rho_minus_i_eta.imag
-    rhobar_plus_i_etabar = sqrt(1-laC**2)*(rho + 1j*eta)/(sqrt(1-A**2*laC**4)+sqrt(1-laC**2)*A**2*laC**4*(rho + 1j*eta)) # e.g. Eq. (92) in arXiv:2206.07501
+    rho_plus_i_eta = np.sin(t13) * np.exp(1j*delta) / (A*laC**3)
+    rhobar_plus_i_etabar = sqrt(1-laC**2)*rho_plus_i_eta/(sqrt(1-A**2*laC**4)+sqrt(1-laC**2)*A**2*laC**4*rho_plus_i_eta) # e.g. Eq. (92) in arXiv:2206.07501
     rhobar = rhobar_plus_i_etabar.real
     etabar = rhobar_plus_i_etabar.imag
     return laC, A, rhobar, etabar

--- a/ckmutil/ckm.py
+++ b/ckmutil/ckm.py
@@ -95,8 +95,8 @@ def beta_gamma_to_delta(beta, gamma, t23, delta_expansion_order=None):
 
     Parameters
     ----------
-    - `gamma`: Unitarity Triangle angle $\gamma$ in radians
     - `beta`: Unitarity Triangle angle $\beta$ in radians
+    - `gamma`: Unitarity Triangle angle $\gamma$ in radians
     - `t23`: CKM angle $\theta_{23}$ in radians
 
     Optional parameters

--- a/ckmutil/test_ckm.py
+++ b/ckmutil/test_ckm.py
@@ -38,6 +38,7 @@ class TestCKM(unittest.TestCase):
     v_w = ckm_wolfenstein(laC, A, rhobar, etabar)
     v_t = ckm_tree(Vus, Vub, Vcb, gamma, delta_expansion_order=None)
     v_wt = ckm_wolfenstein(*tree_to_wolfenstein(Vus, Vub, Vcb, gamma, delta_expansion_order=None))
+    v_b = ckm_beta_gamma(Vus, Vcb, beta, gamma, delta_expansion_order=None)
     par_s = dict(t12=t12,t13=t13,t23=t23,delta=delta)
     par_w = dict(laC=laC,A=A,rhobar=rhobar,etabar=etabar)
     par_t = dict(Vus=Vus,Vub=Vub,Vcb=Vcb,gamma=gamma)
@@ -46,6 +47,7 @@ class TestCKM(unittest.TestCase):
         np.testing.assert_almost_equal(self.v_t/self.v_s, np.ones((3,3)), decimal=5)
         np.testing.assert_almost_equal(self.v_t/self.v_w, np.ones((3,3)), decimal=5)
         np.testing.assert_almost_equal(self.v_t/self.v_wt, np.ones((3,3)), decimal=5)
+        np.testing.assert_almost_equal(self.v_t/self.v_b, np.ones((3,3)), decimal=5)
 
     def test_ckm_unitarity(self):
         np.testing.assert_almost_equal(np.dot(self.v_t,self.v_t.conj().T), np.eye(3), decimal=15)

--- a/ckmutil/test_ckm.py
+++ b/ckmutil/test_ckm.py
@@ -11,23 +11,33 @@ Vcb = 4.0e-2
 gamma = radians(70.) # 70° in radians
 
 # converting to other parametrizations
-t12 = asin(Vus)
-t13 = asin(Vub)
-t23 = asin(Vcb)/cos(t13)
-delta = gamma
+s13 = Vub
+c13 = np.sqrt(1-s13**2)
+s12 = Vus/c13
+c12 = np.sqrt(1-s12**2)
+s23 = Vcb/c13
+c23 = np.sqrt(1-s23**2)
+t12 = asin(s12)
+t13 = asin(s13)
+t23 = asin(s23)
+delta = gamma_to_delta(t12, t13, t23, gamma, delta_expansion_order=None)
 laC = Vus
-A = sin(t23)/laC**2
-rho_minus_i_eta = sin(t13) * cmath.exp(-1j*delta) / (A*laC**3)
+A = s23/laC**2
+rho_minus_i_eta = s13 * cmath.exp(-1j*delta) / (A*laC**3)
 rho = rho_minus_i_eta.real
 eta = -rho_minus_i_eta.imag
-rhobar = rho*(1 - laC**2/2.)
-etabar = eta*(1 - laC**2/2.)
+rhobar_plus_i_etabar = sqrt(1-laC**2)*(rho + 1j*eta)/(sqrt(1-A**2*laC**4)+sqrt(1-laC**2)*A**2*laC**4*(rho + 1j*eta)) # e.q. Eq. (92) in arXiv:2206.07501
+rhobar = rhobar_plus_i_etabar.real
+etabar = rhobar_plus_i_etabar.imag
+Vcd_complex = - s12*c23 - c12*s23*s13 * np.exp(1j*delta)
+Vtd_complex = s12*s23 - c12*c23*s13 * np.exp(1j*delta)
+beta = np.angle(-Vcd_complex/Vtd_complex)
 
 class TestCKM(unittest.TestCase):
     v_s = ckm_standard(t12, t13, t23, delta)
     v_w = ckm_wolfenstein(laC, A, rhobar, etabar)
-    v_t = ckm_tree(Vus, Vub, Vcb, gamma)
-    v_wt = ckm_wolfenstein(*tree_to_wolfenstein(Vus, Vub, Vcb, gamma))
+    v_t = ckm_tree(Vus, Vub, Vcb, gamma, delta_expansion_order=None)
+    v_wt = ckm_wolfenstein(*tree_to_wolfenstein(Vus, Vub, Vcb, gamma, delta_expansion_order=None))
     par_s = dict(t12=t12,t13=t13,t23=t23,delta=delta)
     par_w = dict(laC=laC,A=A,rhobar=rhobar,etabar=etabar)
     par_t = dict(Vus=Vus,Vub=Vub,Vcb=Vcb,gamma=gamma)
@@ -41,3 +51,21 @@ class TestCKM(unittest.TestCase):
         np.testing.assert_almost_equal(np.dot(self.v_t,self.v_t.conj().T), np.eye(3), decimal=15)
         np.testing.assert_almost_equal(np.dot(self.v_w,self.v_w.conj().T), np.eye(3), decimal=15)
         np.testing.assert_almost_equal(np.dot(self.v_s,self.v_s.conj().T), np.eye(3), decimal=15)
+
+    def test_translations_and_inverse(self):
+        np.testing.assert_almost_equal(tuple(self.par_s.values()), tree_to_standard(*standard_to_tree(**self.par_s), delta_expansion_order=None),decimal=15)
+        np.testing.assert_almost_equal(tuple(self.par_w.values()), tree_to_wolfenstein(*wolfenstein_to_tree(**self.par_w), delta_expansion_order=None),decimal=15)
+        np.testing.assert_almost_equal(tuple(self.par_w.values()), standard_to_wolfenstein(*wolfenstein_to_standard(**self.par_w)),decimal=15)
+        np.testing.assert_almost_equal(tuple(self.par_s.values()), beta_gamma_to_standard(*standard_to_beta_gamma(**self.par_s), delta_expansion_order=None),decimal=12)
+
+    def test_gamma_to_delta(self):
+        np.testing.assert_almost_equal(gamma_to_delta(t12, t13, t23, gamma, delta_expansion_order=0), delta, decimal=3)
+        np.testing.assert_almost_equal(gamma_to_delta(t12, t13, t23, gamma, delta_expansion_order=1), delta, decimal=10)
+        np.testing.assert_almost_equal(gamma_to_delta(t12, t13, t23, gamma, delta_expansion_order=2), delta, decimal=15)
+        np.testing.assert_equal(gamma_to_delta(t12, t13, t23, gamma, delta_expansion_order=None), delta)
+
+    def test_beta_gamma_to_delta(self):
+        np.testing.assert_almost_equal(beta_gamma_to_delta(beta, gamma, t23, delta_expansion_order=0), delta, decimal=3)
+        np.testing.assert_almost_equal(beta_gamma_to_delta(beta, gamma, t23, delta_expansion_order=1), delta, decimal=7)
+        np.testing.assert_almost_equal(beta_gamma_to_delta(beta, gamma, t23, delta_expansion_order=2), delta, decimal=10)
+        np.testing.assert_equal(beta_gamma_to_delta(beta, gamma, t23, delta_expansion_order=None), delta)


### PR DESCRIPTION
This PR
- updates the previous implementation of CKM parameterizations, replacing approximate by exact relations,
- adds the new $\beta$ - $\gamma$ parameterization, in which all CKM elements are expressed in terms of the CKM elements $V_{us}$ and $V_{cb}$ and the Unitarity Triangle angles $\beta$ and $\gamma$.

The changes to the previous implementation are:
- The new function `gamma_to_delta` implements the exact relation between $\delta$ and $\gamma$  but its optional argument `delta_expansion_order` allows to use the very accurate approximation $\delta=\gamma$ for `delta_expansion_order=0` or to include higher-order corrections to this approximation for `delta_expansion_order=1` or `delta_expansion_order=2`.
- The new functions `tree_to_standard` and `wolfenstein_to_standard`, and their inverses `standard_to_tree` and `standard_to_wolfenstein` are introduced. They all use exact relations without analytical approximations. In particular, the exact relation between  $\bar\rho + i \bar\eta$ and $\rho + i \eta$ has been implemented for the Wolfenstein parameterization and the exact relation between $\delta$ and $\gamma$ is used everywhere (but the new optional argument `delta_expansion_order` allows to use approximate relations).
- The old function `tree_to_wolfenstein` is now a composition of `tree_to_standard` and `standard_to_wolfenstein` and its inverse `wolfenstein_to_tree` is added as a composition of `wolfenstein_to_standard` and `standard_to_tree`.
- The old function `ckm_wolfenstein` is now a composition of `wolfenstein_to_standard` and `ckm_standard`.
- The old function `ckm_tree` is now a composition of `tree_to_standard` and `ckm_standard`.

The newly implemented $\beta$ - $\gamma$ parameterization consists of:
- The function `beta_gamma_to_delta` that implements the exact relation between $\delta$ and $\gamma$ if $\beta$ is known and its optional argument `delta_expansion_order` allows to use the very accurate approximation $\delta=\gamma$ for `delta_expansion_order=0` or to include higher-order corrections to this approximation for `delta_expansion_order=1` or `delta_expansion_order=2`.
- The new function `beta_gamma_to_standard` and its inverse `standard_to_beta_gamma` implement the translations between the $\beta$ - $\gamma$ parameterization and the standard parameterization.
- The new function `ckm_beta_gamma` implements the CKM matrix in the $\beta$ - $\gamma$ parameterization in terms of a composition of `beta_gamma_to_standard` and `ckm_standard`.

The unittests have been updated and extended.